### PR TITLE
mydb-sts-mysql.yaml파일 오류수정

### DIFF
--- a/Phase4/k8s_mysql/mydb-sts-mysql.yaml
+++ b/Phase4/k8s_mysql/mydb-sts-mysql.yaml
@@ -34,7 +34,7 @@ spec:
         - |
           set -ex
           # Generate the server ID from the serial number of the Pod
-          [[ $(hostname) =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Since the server ID cannot be 0, add 100 to the ID to avoid it
@@ -68,11 +68,11 @@ spec:
           # The copy operation only needs to be started for the first time, so if the data already exists, it will be skipped
           [[ -d /var/lib/mysql/mysql ]] && exit 0
           # The Master node (with sequence number 0) does not need this operation
-          [[ $(hostname) =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           [[ $ordinal -eq 0 ]] && exit 0
           # Use the ncat instruction to remotely copy data from the previous node to the local node
-          ncat --recv-only mydb-$(($ordinal-1)).mydb 3307 | xbstream -x -C /var/lib/mysql
+          ncat --recv-only mydb-0.mydb 3307 | xbstream -x -C /var/lib/mysql
           # Execute -- prepare so that the copied data can be used for recovery
           xtrabackup --prepare --target-dir=/var/lib/mysql
         volumeMounts:


### PR DESCRIPTION
Phase4 실습하다 보니 기본제공된 yaml파일이 잘못되어있어서 수정해보았습니다.
검토한번 부탁드려요^^.
변경내용:
mydb-sts-mysql.yaml 파일 변수변경
37,71라인:  $(hostname) -> $HOSTNAME
75라인:  ncat --recv-only mydb-0.mydb 3307 | xbstream -x -C /var/lib/mysql
 => master로 고정이 되어야 하는데 3번째 pod는 2번째 pod로 연결시도해서 고정값으로 변경했습니다.